### PR TITLE
Troubleshoot missing module error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,8 +52,6 @@ ENV DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
 ARG DJANGO_DEBUG=0
 ENV DJANGO_DEBUG=${DJANGO_DEBUG}
 
-
-RUN python manage.py vendor_pull
 RUN python manage.py collectstatic --noinput
 
 # Set the Django default project name

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ python-decouple
 psycopg[binary]
 dj-database-url
 requests
+commando


### PR DESCRIPTION
Add `commando` to `requirements.txt` and remove `vendor_pull` from `Dockerfile` to fix deployment build errors.

The `commando` module was missing from `requirements.txt` despite being in `INSTALLED_APPS`, causing a `ModuleNotFoundError`. Additionally, the `vendor_pull` command in the Dockerfile did not exist in the project, leading to a build failure.